### PR TITLE
Add analyzer: labels

### DIFF
--- a/cmd/goreview/main.go
+++ b/cmd/goreview/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/einride/goreview/internal/passes/comments"
 	"github.com/einride/goreview/internal/passes/filenames"
 	"github.com/einride/goreview/internal/passes/importgroups"
+	"github.com/einride/goreview/internal/passes/labels"
 	"github.com/einride/goreview/internal/passes/multilineliterals"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/multichecker"
@@ -17,6 +18,7 @@ func allAnalyzers() []*analysis.Analyzer {
 		multilineliterals.Analyzer(),
 		filenames.Analyzer(),
 		comments.Analyzer(),
+		labels.Analyzer(),
 		// ...insert more analyzers here
 	}
 }

--- a/internal/lettercase/camel.go
+++ b/internal/lettercase/camel.go
@@ -1,0 +1,15 @@
+package lettercase
+
+import "unicode"
+
+func IsCamel(s string) bool {
+	for i, r := range s {
+		if i == 0 && !unicode.IsUpper(r) {
+			return false
+		}
+		if r == '_' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/lettercase/camel_test.go
+++ b/internal/lettercase/camel_test.go
@@ -1,0 +1,13 @@
+package lettercase
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCamel(t *testing.T) {
+	require.True(t, IsCamel("CamelCase"))
+	require.False(t, IsCamel("dromedarCase"))
+	require.False(t, IsCamel("Snake_Case"))
+}

--- a/internal/passes/labels/labels.go
+++ b/internal/passes/labels/labels.go
@@ -1,0 +1,35 @@
+package labels
+
+import (
+	"go/ast"
+
+	"github.com/einride/goreview/internal/lettercase"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const Doc = `review labels`
+
+func Analyzer() *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name:     "labels",
+		Doc:      Doc,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+		Run:      run,
+	}
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspectResult := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{
+		(*ast.LabeledStmt)(nil),
+	}
+	inspectResult.Preorder(nodeFilter, func(n ast.Node) {
+		labeledStmt := n.(*ast.LabeledStmt)
+		if !lettercase.IsCamel(labeledStmt.Label.Name) {
+			pass.Reportf(labeledStmt.Pos(), "labels must use CamelCase")
+		}
+	})
+	return nil, nil
+}

--- a/internal/passes/labels/labels_test.go
+++ b/internal/passes/labels/labels_test.go
@@ -1,0 +1,13 @@
+package labels_test
+
+import (
+	"testing"
+
+	"github.com/einride/goreview/internal/passes/labels"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, labels.Analyzer(), "a")
+}

--- a/internal/passes/labels/testdata/src/a/a.go
+++ b/internal/passes/labels/testdata/src/a/a.go
@@ -1,0 +1,22 @@
+package a
+
+func A() {
+GoodLabel:
+	for i := 0; i < 100; i++ {
+		if i == 54 {
+			break GoodLabel
+		}
+	}
+badLabel: // want "labels must use CamelCase"
+	for i := 0; i < 100; i++ {
+		if i == 54 {
+			break badLabel
+		}
+	}
+Bad_label: // want "labels must use CamelCase"
+	for i := 0; i < 100; i++ {
+		if i == 54 {
+			break Bad_label
+		}
+	}
+}


### PR DESCRIPTION
Verifies that labels use CamelCase, as shown in the Effective Go
documentation.