### PR TITLE
Revert "disable pkgerrors analyzer until all projects are > 1.13"

### DIFF
--- a/cmd/goreview/main.go
+++ b/cmd/goreview/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/einride/goreview/internal/passes/importgroups"
 	"github.com/einride/goreview/internal/passes/labels"
 	"github.com/einride/goreview/internal/passes/multilineliterals"
+	"github.com/einride/goreview/internal/passes/pkgerrors"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/multichecker"
 )
@@ -19,6 +20,7 @@ func allAnalyzers() []*analysis.Analyzer {
 		filenames.Analyzer(),
 		comments.Analyzer(),
 		labels.Analyzer(),
+		pkgerrors.Analyzer(),
 		// ...insert more analyzers here
 	}
 }


### PR DESCRIPTION
This reverts commit 178b2e31f87f27f52bcdc8a51ad336df95cf7f33.