### PR TITLE
feat: relax multilinefunctions linter

### DIFF
--- a/internal/passes/multilinefunctions/testdata/src/c/function_calls.go
+++ b/internal/passes/multilinefunctions/testdata/src/c/function_calls.go
@@ -26,7 +26,7 @@ func foo() {
 		}, A{}, // want `each argument should start on a new line`
 	)
 	a(
-		A{}, A{}, // want `each argument should start on a new line`
+		A{}, A{}, // ok
 	)
 	a(
 		A{},


### PR DESCRIPTION
Too aggressive. For example on the snippet:

~~~go
strings.NewReplacer(
   "0", "a", "1", "b", "2", "c", "3", "d", "4", "e", "5",
)
~~~

This should now be valid.