### PR TITLE
feat: skip analysis of function calls with > 5 args

### DIFF
--- a/internal/passes/multilinefunctions/multilinefunctions.go
+++ b/internal/passes/multilinefunctions/multilinefunctions.go
@@ -37,6 +37,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return nil, nil
 }
 
+// maxArgsToAnalyze is the maximum number of arguments to apply this rule to.
+// Calls with more args are considered special cases where special formatting is allowed.
+const maxCallArgsToAnalyze = 5
+
 func analyseFunctionCall(pass *analysis.Pass, call *ast.CallExpr) {
 	lastLine := pass.Fset.Position(call.Rparen).Line
 	firstLine := pass.Fset.Position(call.Lparen).Line
@@ -45,6 +49,9 @@ func analyseFunctionCall(pass *analysis.Pass, call *ast.CallExpr) {
 	}
 	if len(call.Args) == 0 {
 		return
+	}
+	if len(call.Args) > maxCallArgsToAnalyze {
+		return // too many fields
 	}
 	if isSingleLineCall(pass, call) {
 		return

--- a/internal/passes/multilinefunctions/testdata/src/c/function_calls.go
+++ b/internal/passes/multilinefunctions/testdata/src/c/function_calls.go
@@ -4,7 +4,7 @@ type A struct {
 	a *A
 }
 
-func a(A, A) {}
+func a(...A) {}
 
 func foo() {
 	a(A{}, A{}) // ok
@@ -19,6 +19,10 @@ func foo() {
 	a(
 		A{},
 		A{},
+	) // ok
+	a(
+		A{}, A{}, A{},
+		A{}, A{}, A{},
 	) // ok
 	a(
 		A{


### PR DESCRIPTION
This many args is treated as a special-case where any line wrapping is
OK.

For example applicable to code generation with `f.P()`-style APIs.
