### PR TITLE
Add analyzers for migration from ptypes and testify

### DIFF
--- a/internal/passes/ptypes/analyzer.go
+++ b/internal/passes/ptypes/analyzer.go
@@ -1,0 +1,34 @@
+package ptypes
+
+import "golang.org/x/tools/go/analysis"
+
+const ptypesPackage = `"github.com/golang/protobuf/ptypes"`
+
+const knownTypesPackage = `"google.golang.org/protobuf/types/known"`
+
+const Doc = `check for usage of deprecated package ` + ptypesPackage
+
+func Analyzer() *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: "ptypes",
+		Doc:  Doc,
+		Run:  run,
+	}
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, f := range pass.Files {
+		for _, importSpec := range f.Imports {
+			if importSpec.Path.Value == ptypesPackage {
+				pass.Reportf(
+					importSpec.Pos(),
+					`use the the packages from %s instead of the deprecated package %s (see %s)`,
+					knownTypesPackage,
+					ptypesPackage,
+					"https://github.com/golang/protobuf/releases#v1.4-well-known-types",
+				)
+			}
+		}
+	}
+	return nil, nil
+}

--- a/internal/passes/ptypes/analyzer_test.go
+++ b/internal/passes/ptypes/analyzer_test.go
@@ -1,0 +1,12 @@
+package ptypes
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer(), "a")
+}

--- a/internal/passes/ptypes/testdata/src/a/a.go
+++ b/internal/passes/ptypes/testdata/src/a/a.go
@@ -1,0 +1,7 @@
+package a
+
+import "github.com/golang/protobuf/ptypes" // want `use the the packages from "google.golang.org/protobuf/types/known" instead of the deprecated package "github.com/golang/protobuf/ptypes" \(see https://github.com/golang/protobuf/releases#v1.4-well-known-types\)`
+
+func IllegalImports() {
+	_ = ptypes.TimestampNow()
+}

--- a/internal/passes/ptypes/testdata/src/github.com/golang/protobuf/ptypes/mock.go
+++ b/internal/passes/ptypes/testdata/src/github.com/golang/protobuf/ptypes/mock.go
@@ -1,0 +1,7 @@
+package ptypes
+
+import "google.golang.org/protobuf/types/known/timestamppb"
+
+func TimestampNow() *timestamppb.Timestamp {
+	return nil
+}

--- a/internal/passes/ptypes/testdata/src/google.golang.org/protobuf/types/known/timestamppb/mock.go
+++ b/internal/passes/ptypes/testdata/src/google.golang.org/protobuf/types/known/timestamppb/mock.go
@@ -1,0 +1,3 @@
+package timestamppb
+
+type Timestamp struct{}

--- a/internal/passes/testify/analyzer.go
+++ b/internal/passes/testify/analyzer.go
@@ -1,0 +1,39 @@
+package testify
+
+import (
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const Doc = `check for usage of testify and recommend to use gotest`
+
+const (
+	testifyModule  = "github.com/stretchr/testify"
+	gotestV3Module = "gotest.tools/v3"
+)
+
+func Analyzer() *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: "testify",
+		Doc:  Doc,
+		Run:  run,
+	}
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, f := range pass.Files {
+		for _, importSpec := range f.Imports {
+			if strings.HasPrefix(importSpec.Path.Value, `"`+testifyModule) {
+				pass.Reportf(
+					importSpec.Pos(),
+					`use test assertions from "%s" instead of "%s" (see %s)`,
+					gotestV3Module,
+					testifyModule,
+					"https://pkg.go.dev/gotest.tools/v3/assert",
+				)
+			}
+		}
+	}
+	return nil, nil
+}

--- a/internal/passes/testify/analyzer_test.go
+++ b/internal/passes/testify/analyzer_test.go
@@ -1,0 +1,12 @@
+package testify
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer(), "a")
+}

--- a/internal/passes/testify/testdata/src/a/a.go
+++ b/internal/passes/testify/testdata/src/a/a.go
@@ -1,0 +1,11 @@
+package a
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert" // want `use test assertions from "gotest.tools/v3" instead of "github.com/stretchr/testify" \(see https://pkg.go.dev/gotest.tools/v3/assert\)`
+)
+
+func IllegalImport(t *testing.T) {
+	assert.Equal(t, 1, 1)
+}

--- a/internal/passes/testify/testdata/src/github.com/stretchr/testify/assert/mock.go
+++ b/internal/passes/testify/testdata/src/github.com/stretchr/testify/assert/mock.go
@@ -1,0 +1,6 @@
+package assert
+
+import "testing"
+
+func Equal(t *testing.T, a, b interface{}) {
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"go.einride.tech/review/internal/passes/multilineliterals"
 	"go.einride.tech/review/internal/passes/ptypes"
 	"go.einride.tech/review/internal/passes/stderror"
+	"go.einride.tech/review/internal/passes/testify"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/multichecker"
 )
@@ -25,6 +26,7 @@ func allAnalyzers() []*analysis.Analyzer {
 		labels.Analyzer(),
 		stderror.Analyzer(),
 		ptypes.Analyzer(),
+		testify.Analyzer(),
 		// ...insert more analyzers here
 	}
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"go.einride.tech/review/internal/passes/labels"
 	"go.einride.tech/review/internal/passes/multilinefunctions"
 	"go.einride.tech/review/internal/passes/multilineliterals"
+	"go.einride.tech/review/internal/passes/ptypes"
 	"go.einride.tech/review/internal/passes/stderror"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/multichecker"
@@ -23,6 +24,7 @@ func allAnalyzers() []*analysis.Analyzer {
 		comments.Analyzer(),
 		labels.Analyzer(),
 		stderror.Analyzer(),
+		ptypes.Analyzer(),
 		// ...insert more analyzers here
 	}
 }


### PR DESCRIPTION
- feat: add analyzer for deprecated ptypes package
- feat: add analyzer recommending migration from testify to gotest
