### PR TITLE
go 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
 
       - name: Setup Node
         uses: actions/setup-node@v2.1.4
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
 
       - name: Setup Node
         uses: actions/setup-node@v2.1.4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,3 +15,6 @@ linters:
     - unparam # allow constant parameters
     - goerr113 # allow "dynamic" errors
     - nlreturn # don't require blank lines before returns
+    - paralleltest # TODO: make tests paralleltest
+    - exhaustivestruct # don't require exhaustive structs
+    - cyclop # allow complex functions

--- a/go.sum
+++ b/go.sum
@@ -24,7 +24,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200831203904-5a2aa26beb65 h1:DajXNh69ob79PCQz1N7OHxmqq6ASZC5xAnJJWIQGR6I=
 golang.org/x/tools v0.0.0-20200831203904-5a2aa26beb65/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=

--- a/tools/golangci-lint/rules.mk
+++ b/tools/golangci-lint/rules.mk
@@ -1,5 +1,5 @@
 golangci_lint_cwd := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-golangci_lint_version := 1.30.0
+golangci_lint_version := 1.37.0
 golangci_lint := $(golangci_lint_cwd)/$(golangci_lint_version)/golangci-lint
 
 ifeq ($(shell uname),Linux)


### PR DESCRIPTION
- ci(deps): bump GolangCI-Lint
- ci(deps): bump Go to 1.16
