### PR TITLE
feat: add support for go 1.16 embed and golangci-lint

### DIFF
--- a/internal/passes/comments/comments.go
+++ b/internal/passes/comments/comments.go
@@ -24,8 +24,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 					// ignore empty comments
 					continue
 				}
-				if strings.HasPrefix(g.Text, "//go:generate") {
-					// ignore go:generate comments
+				switch {
+				case strings.HasPrefix(g.Text, "//go:generate"), // ignore go:generate comments
+					strings.HasPrefix(g.Text, "//go:embed"), // ignore go:embed comments
+					strings.HasPrefix(g.Text, "//nolint"):   // ignore nolint comments
 					continue
 				}
 				if !strings.HasPrefix(g.Text, "// ") {

--- a/internal/passes/comments/testdata/src/a/a.go
+++ b/internal/passes/comments/testdata/src/a/a.go
@@ -6,6 +6,9 @@ import (
 )
 
 //go:generate echo go generate comments are OK!
+//go:embed echo go embed commentts are OK!
+//nolint echo nolint comments are OK!
+//nolint:specifilinter echo specific linter comments are OK!
 
 func Imports() {
 	// good comment


### PR DESCRIPTION
* Go 1.16 uses //go:embed
* Golangci-lint uses //nolint to bypass linters
