### PR TITLE
fix(release): correctly build release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true
 
+  goreleaser:
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Sage
+        uses: einride/sage/actions/setup@master
+
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v2.9.1
         with:


### PR DESCRIPTION
the tag that is needed by goreleaser wasn't made available. Having goreleaser in a separate job fixes this.