### PR TITLE
fix(comments): adhere to go 1.19 gofmt new formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+.vscode
 .semrel
 .generated-go-semantic-release-changelog.md

--- a/internal/passes/comments/comments.go
+++ b/internal/passes/comments/comments.go
@@ -32,7 +32,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 					strings.HasPrefix(g.Text, "//go:cgo"):   // ignore cgo generated imports
 					continue
 				}
-				if !strings.HasPrefix(g.Text, "// ") {
+				if !(strings.HasPrefix(g.Text, "// ") || strings.HasPrefix(g.Text, "//\t")) {
 					pos := g.Slash
 					// special case for tests, since tests use comments for assertions
 					// expect the assertion to be located directly above the failing comment

--- a/internal/passes/comments/testdata/src/a/a.go
+++ b/internal/passes/comments/testdata/src/a/a.go
@@ -1,4 +1,5 @@
 package a
+
 //go:cgo_
 
 import (
@@ -10,12 +11,13 @@ import (
 //go:embed echo go embed commentts are OK!
 //nolint echo nolint comments are OK!
 //nolint:specifilinter echo specific linter comments are OK!
-//go:build echo go build comments are OK!
 
 func Imports() {
 	// good comment
 	//
 	// also good
+	//
+	//	still a valid comment (with a tab)
 	log.Println("hello")
 	// want "comments must start with '// '"
 	//bad comment


### PR DESCRIPTION
Test is updated but "go:build" line is removed as new gofmt automatically changes the line, making analysistest report an error.

In the release notes:
> As part of this change, [gofmt](https://tip.golang.org/cmd/gofmt) now reformats doc comments to make their rendered meaning clearer.

And in the `doc` page:
> Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment. Alignment assumes that an editor is using a fixed-width font.

More info [here](https://tip.golang.org/doc/go1.19#go-doc) and [there](https://tip.golang.org/doc/comment).

Co-authored-by: Andrei Sousa <sousandrei@gmail.com>
