### PR TITLE
fix: bump toolchain to Go 1.22

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -2,6 +2,6 @@ module sage
 
 go 1.21
 
-toolchain go1.21.0
+toolchain go1.22.1
 
 require go.einride.tech/sage v0.272.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.einride.tech/review
 
 go 1.21
 
-toolchain go1.21.0
+toolchain go1.22.1
 
 require (
 	golang.org/x/tools v0.18.0


### PR DESCRIPTION
Bumping Go to 1.22 and using the latest toolchain release. Looking back at the previous bump PR (#202) and the addition of `toolchain` in go.mod this should be enough.

The symptoms for when a bump is needed (to my knowledge) is when you get function signature mismatches for standard lib functions, for example:
```
reviewing Go files...
<file>.go:<line>:<col>: too many arguments in call to unix.Mount
have (string, string, string, number, string)
want (string, string, int, unsafe.Pointer)
-: This application uses version go1.21 of the source-processing packages but runs version go1.22 of 'go list'. It may fail to process source files that rely on newer language features. If so, rebuild the application using a newer version of Go.
```